### PR TITLE
Fix(21): JsonAlBhedTransferAdapter を JsonAlBhedTranslatorAdapter にリネーム

### DIFF
--- a/src/infrastracture/web.rs
+++ b/src/infrastracture/web.rs
@@ -3,9 +3,9 @@ use std::env;
 use actix_cors::Cors;
 use actix_web::{get, post, web, App, HttpResponse, HttpServer};
 
-use crate::interface::adapter::JsonAlBhedTransferAdapter;
+use crate::interface::adapter::JsonAlBhedTranslatorAdapter;
 
-pub async fn start_server(adapter: JsonAlBhedTransferAdapter) -> std::io::Result<()> {
+pub async fn start_server(adapter: JsonAlBhedTranslatorAdapter) -> std::io::Result<()> {
     let port = env::var("BACKEND_PORT")
         .ok()
         .and_then(|p| p.parse().ok())
@@ -35,7 +35,7 @@ pub async fn start_server(adapter: JsonAlBhedTransferAdapter) -> std::io::Result
 #[post("/encode")]
 async fn encode_handler(
     body: String,
-    adapter: web::Data<JsonAlBhedTransferAdapter>,
+    adapter: web::Data<JsonAlBhedTranslatorAdapter>,
 ) -> HttpResponse {
     match adapter.encode(&body) {
         Ok(response) => HttpResponse::Ok()
@@ -48,7 +48,7 @@ async fn encode_handler(
 #[post("/decode")]
 async fn decode_handler(
     body: String,
-    adapter: web::Data<JsonAlBhedTransferAdapter>,
+    adapter: web::Data<JsonAlBhedTranslatorAdapter>,
 ) -> HttpResponse {
     match adapter.decode(&body) {
         Ok(response) => HttpResponse::Ok()
@@ -74,7 +74,8 @@ mod tests {
     async fn test_encode_endpoint_valid() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(adapter))
@@ -99,7 +100,8 @@ mod tests {
     async fn test_encode_endpoint_invalid() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(adapter))
@@ -121,7 +123,8 @@ mod tests {
     async fn test_decode_endpoint_valid() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(adapter))
@@ -146,7 +149,8 @@ mod tests {
     async fn test_decode_endpoint_invalid() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(adapter))
@@ -168,7 +172,8 @@ mod tests {
     async fn test_health_check() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let app = test::init_service(
             App::new()
                 .app_data(web::Data::new(adapter))

--- a/src/interface/adapter.rs
+++ b/src/interface/adapter.rs
@@ -16,17 +16,17 @@ pub struct AlBhedTransferResponse {
     result: String,
 }
 
-pub struct JsonAlBhedTransferAdapter {
+pub struct JsonAlBhedTranslatorAdapter {
     encode_input_port: Box<dyn EncodeInputPort + Sync + Send>,
     decode_input_port: Box<dyn DecodeInputPort + Sync + Send>,
 }
 
-impl JsonAlBhedTransferAdapter {
+impl JsonAlBhedTranslatorAdapter {
     pub fn new(
         encode_port: Box<dyn EncodeInputPort + Sync + Send>,
         decode_port: Box<dyn DecodeInputPort + Sync + Send>,
     ) -> Self {
-        JsonAlBhedTransferAdapter {
+        JsonAlBhedTranslatorAdapter {
             encode_input_port: encode_port,
             decode_input_port: decode_port,
         }
@@ -74,7 +74,8 @@ mod tests {
     fn test_encode_valid_json() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let json = r#"{"text": "がんばろう！"}"#;
         let result = adapter.encode(json).unwrap();
         assert_eq!(result, r#"{"result":"ダンザノフ！"}"#);
@@ -84,7 +85,8 @@ mod tests {
     fn test_encode_invalid_json() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let json = r#"invalid json"#;
         let result = adapter.encode(json);
         assert!(result.is_err());
@@ -94,7 +96,8 @@ mod tests {
     fn test_decode_valid_json() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let json = r#"{"text": "ヤヌサー"}"#;
         let result = adapter.decode(json).unwrap();
         assert_eq!(result, r#"{"result":"ますたー"}"#);
@@ -104,7 +107,8 @@ mod tests {
     fn test_decode_invalid_json() {
         let encode_port = EncodeInteractor::new();
         let decode_port = DecodeInteractor::new();
-        let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+        let adapter =
+            JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
         let json = r#"invalid json"#;
         let result = adapter.decode(json);
         assert!(result.is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use albhed_translator_service::{
     infrastracture::web,
-    interface::adapter::JsonAlBhedTransferAdapter,
+    interface::adapter::JsonAlBhedTranslatorAdapter,
     usecase::{decode_usecase::DecodeInteractor, encode_usecase::EncodeInteractor},
 };
 
@@ -8,6 +8,6 @@ use albhed_translator_service::{
 async fn main() -> std::io::Result<()> {
     let encode_port = EncodeInteractor::new();
     let decode_port = DecodeInteractor::new();
-    let adapter = JsonAlBhedTransferAdapter::new(Box::new(encode_port), Box::new(decode_port));
+    let adapter = JsonAlBhedTranslatorAdapter::new(Box::new(encode_port), Box::new(decode_port));
     web::start_server(adapter).await
 }


### PR DESCRIPTION
## 変更内容
- JsonAlBhedTransferAdapter を JsonAlBhedTranslatorAdapter にリネーム
- adapter.rs, main.rs, web.rs の全ての参照を更新
- cargo fmt でフォーマット修正
## 検証結果
- cargo build --release: OK
- cargo test: 14 tests passed
- cargo clippy --all-targets --all-features: OK
- cargo fmt --all --check: OK
## 関連
Closes #21